### PR TITLE
auto delete timer up to 1 year

### DIFF
--- a/lib/pages/settings/general_page.dart
+++ b/lib/pages/settings/general_page.dart
@@ -115,8 +115,8 @@ class _GeneralPageState extends State<GeneralPage> {
                 title: Expanded(
                     child: CupertinoSlider(
                   min: 1,
-                  max: 4,
-                  divisions: 3,
+                  max: 52,
+                  divisions: 51,
                   value: (globalModel.keepItemsDays ~/ 7).toDouble(),
                   onChanged: (v) {
                     globalModel.keepItemsDays = (v * 7).toInt();


### PR DESCRIPTION
I found 4 weeks cap very limiting and arbitrary. I often leave things unread for 2-3 months. Changing slider to 1 year is also very arbitrary, but it's quick and easy stopgap. Should be unlimited numeric input really, but i don't want to figure out new framework and setting up whole android SDK...