### PR TITLE
add parameters for miniflux server

### DIFF
--- a/lib/models/services/greader.dart
+++ b/lib/models/services/greader.dart
@@ -162,7 +162,8 @@ class GReaderServiceHandler extends ServiceHandler {
   @override
   Future<bool> validate() async {
     try {
-      final result = await _fetchAPI("/reader/api/0/user-info");
+      // add output param for miniflux server
+      final result = await _fetchAPI("/reader/api/0/user-info?output=json");
       return result.statusCode == 200;
     } catch (exp) {
       return false;


### PR DESCRIPTION
The `/reader/api/0/user-info` interface of miniflux's Google reader api requires `output` as a request parameter.
It has also been tested with FreshRSS and is compatible with this parameter.

There is relevant code here, please check it if needed: 
https://github.com/miniflux/v2/blob/b205b5aad075dc89040231f87c79bec2a7ea60c7/internal/googlereader/handler.go#L1256

There are related comments here: 
![image](https://github.com/yang991178/fluent-reader-lite/assets/41715438/c6bdb18a-9ce9-43b2-92bb-a0e649d5e7f4)
Link: https://github.com/miniflux/v2/issues/2129#issuecomment-1802327014